### PR TITLE
fix: make StudentResponseDto.Grades property read-only for CA2227

### DIFF
--- a/API/Controllers/StudentsController.cs
+++ b/API/Controllers/StudentsController.cs
@@ -63,17 +63,7 @@ public sealed class StudentsController : ControllerBase
         _ = _context.Students.Add(student);
         _ = await _context.SaveChangesAsync();
 
-        var studentDto = new StudentResponseDto
-        {
-            Id = student.Id,
-            Name = student.Name,
-            Email = student.Email,
-            CreatedAt = student.CreatedAt,
-            AverageGrade = 0.0,
-            Grades = new List<GradeResponseDto>(),
-        };
-
-        return CreatedAtAction(nameof(GetStudent), new { id = student.Id }, studentDto);
+        return CreatedAtAction(nameof(GetStudent), new { id = student.Id }, student.ToResponseDto());
     }
 
     // PUT: api/Students/5

--- a/API/Extensions/MappingExtensions.cs
+++ b/API/Extensions/MappingExtensions.cs
@@ -8,15 +8,21 @@ public static class MappingExtensions
     {
         ArgumentNullException.ThrowIfNull(student);
 
-        return new StudentResponseDto
+        var dto = new StudentResponseDto
         {
             Id = student.Id,
             Name = student.Name,
             Email = student.Email,
             CreatedAt = student.CreatedAt,
             AverageGrade = student.AverageGrade,
-            Grades = student.Grades.Select(g => g.ToResponseDto()).ToList(),
         };
+
+        foreach (var grade in student.Grades)
+        {
+            dto.Grades.Add(grade.ToResponseDto());
+        }
+
+        return dto;
     }
 
     public static GradeResponseDto ToResponseDto(this Grade grade)

--- a/API/Models/DTOs.cs
+++ b/API/Models/DTOs.cs
@@ -63,7 +63,7 @@ public sealed class StudentResponseDto
 
     public double AverageGrade { get; set; }
 
-    public IList<GradeResponseDto> Grades { get; set; } = new List<GradeResponseDto>();
+    public IList<GradeResponseDto> Grades { get; } = new List<GradeResponseDto>();
 }
 
 // DTO for grade response

--- a/StudentGradesAPI.Tests/Models/DTOTests.cs
+++ b/StudentGradesAPI.Tests/Models/DTOTests.cs
@@ -167,8 +167,12 @@ public class DTOTests
             Email = expectedEmail,
             CreatedAt = expectedCreatedAt,
             AverageGrade = expectedAverageGrade,
-            Grades = expectedGrades,
         };
+
+        foreach (var grade in expectedGrades)
+        {
+            dto.Grades.Add(grade);
+        }
 
         // Assert
         dto.Id.Should().Be(expectedId);


### PR DESCRIPTION
fix: make StudentResponseDto.Grades property read-only for CA2227 compliance